### PR TITLE
Allows a direct click on the `&laquo;` and `&raquo;` to toggle the panel

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -259,8 +259,8 @@ call.on('stream', function(stream) {
   <header class="left">
     <h2>
       API Reference
-      <a class="hide icon">&laquo;</a>
-      <a class="show icon">&raquo;</a>
+      <span class="hide icon">&laquo;</span>
+      <span class="show icon">&raquo;</span>
     </h2>
   </header>
   <header class="right">


### PR DESCRIPTION
Hi 👋 
<img width="413" alt="Screen Shot 2022-05-18 at 5 53 44 PM" src="https://user-images.githubusercontent.com/1775593/169173851-7d753608-d2b1-4e9f-9df0-412c7d9d7ed2.png">

I clicked directly on the "«" with no effect more times than I care to admit before figuring out how to close the sidebar 🤣 

The anchor tag seems to be preventing the click handler from opening and closing the sidebar. Simply swapping the `a` out for a `span` fixes it for me when I run it locally, and it looks the same as far as I can tell.

