### PR TITLE
Update links on team page

### DIFF
--- a/views/team.ejs
+++ b/views/team.ejs
@@ -4,29 +4,30 @@
     <span class="random_tagline"></span>.</p>
   <br>
   <div class="person">
-    <div class="img" id="michelle"></div>
+    <a href="https://github.com/michelle">
+      <div class="img" id="michelle"></div>
+    </a>
     <div class="text">
       <h3>
-        <a href="http://github.com/michellebu">Michelle Bu</a>
+        <a href="https://github.com/michelle">Michelle Bu</a>
       </h3>
       <p>I mostly build silly Javascript web applications. I am working on this Javascript library so I can build more silly
         Javascript web applications.</p>
     </div>
   </div>
   <div class="person">
-    <a href="http://twitter.com/reallyez">
+    <a href="https://github.com/ericz">
       <div class="img" id="eric"></div>
     </a>
     <div class="text">
       <h3>
-        <a href="http://github.com/ericz">Eric Zhang</a>
+        <a href="https://github.com/ericz">Eric Zhang</a>
       </h3>
       <p>I'm not going to lie, I am addicted to writing Javascript libraries.
         <br>Please stop me.
         <br>Previously I've built
-        <a href="http://binaryjs.com">BinaryJS</a> and before that I was a founder of Y Combinator startup Flotype, building, you guessed it, Javascript
+        <a href="https://github.com/binaryjs/binaryjs">BinaryJS</a> and before that I was a founder of Y Combinator startup Flotype, building, you guessed it, Javascript
         (among others) libraries.</p>
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
I've noticed that one of the GitHub profile links needed to be corrected, that the Twitter profile is no longer active, and that the BinaryJS homepage was not active anymore. This PR fixes those links.