### PR TITLE
Remove outdated warning about Firefox not supporting the "close" event

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -1025,9 +1025,7 @@ call.on('stream', function(stream) {
               >
               <p class="description">
                 Emitted when either you or the remote peer closes the data
-                connection.<span class="warn"
-                  >Firefox does not yet support this event.</span
-                >
+                connection.
               </p>
             </div>
             <div class="child" id="dataconnection-on-error">
@@ -1254,9 +1252,6 @@ call.on('stream', function(stream) {
               <p class="description">
                 Emitted when either you or the remote peer closes the media
                 connection.
-                <span class="warn"
-                  >Firefox does not yet support this event.</span
-                >
               </p>
             </div>
             <div class="child" id="mediaconnection-on-error">


### PR DESCRIPTION
I've checked it on Firefox v108.0.1, and confirmed Firefox supports the  "close" event.